### PR TITLE
added option for browserifyConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,19 @@ A usage example is below. See the [babel docs](http://babeljs.io/docs/usage/opti
 }
 ```
 
+##### browserifyConfig
+
+Type: `Object`  
+Default: `{ standalone: 'Contents', debug: true }`
+
+A usage example is below. See the [browserify docs](https://github.com/substack/node-browserify#browserifyfiles--opts) for the complete list.
+
+``` js
+{
+  extensions: ['', '.js', '.jsx']
+}
+```
+
 ### rsg.generate([callback])
 
 Generate the files and their dependencies into a styleguide output.

--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -21,6 +21,7 @@ var mustache = require('mustache')
  * @param {boolean=} opts.pushstate
  * @param {string[]=} opts.files
  * @param {Object=} opts.babelConfig
+ * @param {Object=} opts.browserifyConfig
  */
 function RSG (input, opts) {
   opts = opts || {}
@@ -32,6 +33,7 @@ function RSG (input, opts) {
   opts.pushstate = opts.pushstate || false
   opts.files = opts.files || []
   opts.babelConfig = opts.babelConfig || null
+  opts.browserifyConfig = assign(opts.browserifyConfig || {}, { standalone: 'Contents', debug: true })
 
   this.input = glob.sync(input, { realpath: true })
   this.opts = opts
@@ -164,7 +166,7 @@ RSG.prototype.createContentsFile = function () {
   data = 'module.exports = [' + data.join(',') + ']'
   fs.outputFileSync(dest, data)
 
-  var b = browserify(dest, { standalone: 'Contents', debug: true })
+  var b = browserify(dest, this.opts.browserifyConfig)
     .transform(babelify.configure(this.opts.babelConfig))
     .external('react')
     .external('react/addons')

--- a/test/rsg.js
+++ b/test/rsg.js
@@ -19,6 +19,10 @@ function RSG (input, opts) {
     config: null,
     babelConfig: {
       stage: 0
+    },
+    browserifyConfig: {
+      standalone: 'Contents',
+      debug: true
     }
   }
 
@@ -126,6 +130,20 @@ describe('RSG', function () {
       var babelConfig = { stage: 0 }
       var rsg = RSG(INPUT_FILE, { babelConfig: babelConfig })
       assert.deepEqual(rsg.opts.babelConfig, babelConfig)
+    })
+  })
+
+  describe('opts.browserifyConfig', function () {
+    it('should default to { standalone: \'Contents\', debug: true }', function () {
+      var browserifyConfig = { standalone: 'Contents', debug: true }
+      var rsg = RSG(INPUT_FILE, { browserifyConfig: undefined })
+      assert.deepEqual(rsg.opts.browserifyConfig, browserifyConfig)
+    })
+
+    it('should merge with defaults', function () {
+      var browserifyMergedConfig = { standalone: 'Contents', debug: true, extensions: ['', '.js', '.jsx'] }
+      var rsg = RSG(INPUT_FILE, { browserifyConfig: { extensions: ['', '.js', '.jsx'] } })
+      assert.deepEqual(rsg.opts.browserifyConfig, browserifyMergedConfig)
     })
   })
 


### PR DESCRIPTION
By default browserify doesn't handle `.jsx` files, so I was getting errors on imports without using the extension, this fixed it.

Added tests and documentation, let me know if anything's missing.