### PR TITLE
Fix watch issue where altering props documentation does not re-parse

### DIFF
--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -71,6 +71,9 @@ function RSG (input, opts) {
   // files that have not changed in react-docgen for perf
   this.reactDocGenCache = {}
 
+  // has the first-pass of parsing happened?
+  this.reactDocGenInit = false
+
   // Cached files to include into the styleguide app
   this.cssFiles = this.extractFiles('.css')
   this.jsFiles = this.extractFiles('.js')
@@ -137,7 +140,9 @@ RSG.prototype.genReactPropDoc = function () {
           var displayName = propMetadata.displayName
 
           if (displayName) {
-            if (self.reactPropMetas[displayName]) {
+            // only check for duplicate displayNames on the first pass
+            // subsequent passes, we can assume we're regenerating the prop information
+            if (self.reactPropMetas[displayName] && !self.reactDocGenInit) {
               reject(new Error('displayName already exists: ' + displayName))
             } else {
               self.reactPropMetas[displayName] = propMetadata
@@ -152,6 +157,8 @@ RSG.prototype.genReactPropDoc = function () {
       }
 
     })
+
+    self.reactDocGenInit = true
 
     resolve()
   })


### PR DESCRIPTION
This fixes an issue when using the watch mode.

When you alter the props documentation, the page will not be reloaded with the updated props.

```
  propTypes: {
    /**
     * Type of calendar interaction
     */
    selectionType: React.PropTypes.string
```

If I change the documentation comment in watch mode, does not parse the new comment.

PS Could you publish a new npm version once this PR is in? Thanks!