### PR TITLE
change misc for react 0.14 & react-dom compatibility

### DIFF
--- a/app/components/Search/index.js
+++ b/app/components/Search/index.js
@@ -23,7 +23,7 @@ export default class Search extends Component {
   }
 
   focus () {
-    let input = React.findDOMNode(this.refs.q)
+    let input = this.refs.q
 
     input.focus()
   }
@@ -43,7 +43,7 @@ export default class Search extends Component {
    * @param {Event} e
    */
   onSubmit (e) {
-    let val = React.findDOMNode(this.refs.q).value
+    let val = this.refs.q.value
     let url = `/search/${val}`
 
     e.preventDefault()

--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import ReactDOM from 'react-dom'
 import page from 'page'
 import App from './components/App'
 
@@ -8,21 +9,21 @@ let mountNode = document.getElementById('app')
  * Home
  */
 page('.', (ctx) => {
-  React.render(<App ctx={ctx} />, mountNode)
+  ReactDOM.render(<App ctx={ctx} />, mountNode)
 })
 
 /**
  * Search Result
  */
 page('/search/:query?', (ctx) => {
-  React.render(<App ctx={ctx} />, mountNode)
+  ReactDOM.render(<App ctx={ctx} />, mountNode)
 })
 
 /**
  * Category and Detail
  */
 page('/:category/:title?', (ctx) => {
-  React.render(<App ctx={ctx} />, mountNode)
+  ReactDOM.render(<App ctx={ctx} />, mountNode)
 })
 
 /**

--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -264,6 +264,7 @@ RSG.prototype.createReactFile = function () {
   var b = browserify({ debug: true })
     .require('react')
     .require('react/addons')
+    .require('react-dom')
 
   return new Promise(function (resolve, reject) {
     b.bundle(function (err, buffer) {
@@ -298,6 +299,7 @@ RSG.prototype.createContentsFile = function () {
   b.transform(babelify.configure(self.opts.babelConfig))
     .external('react')
     .external('react/addons')
+    .external('react-dom')
 
   function distContentsFile () {
     return new Promise(function (resolve, reject) {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "prod": "npm run clean && npm run build",
     "build": "npm run build:css && npm run build:js",
     "build:css": "cssnext -c app/index.css dist/app.css",
-    "build:js": "browserify -t [babelify --stage 0] -x react app | uglifyjs -m -o dist/app.js",
+    "build:js": "browserify -t [babelify --stage 0] -x react -x react-dom app | uglifyjs -m -o dist/app.js",
     "dev-build": "npm run dev-build:css && npm run dev-build:js",
     "dev-build:css": "cssnext -s app/index.css dist/app.css",
-    "dev-build:js": "browserify -d -t [babelify --stage 0] -x react app -o dist/app.js",
+    "dev-build:js": "browserify -d -t [babelify --stage 0] -x react -x react-dom app -o dist/app.js",
     "clean": "rimraf dist/*",
     "styleguide": "node bin/rsg 'example/components/**/*.js' -v",
     "ghpages": "npm run styleguide -- -r 'react-styleguide-generator' && gh-pages -d styleguide"
@@ -69,7 +69,7 @@
     "node": ">=0.10.33"
   },
   "peerDependencies": {
-    "react": ">=0.13"
+    "react": ">=0.14"
   },
   "dependencies": {
     "babel": "^5.8.19",
@@ -93,8 +93,9 @@
     "marked": "^0.3.3",
     "mocha": "^2.2.5",
     "page": "1.6.3",
-    "react": "^0.13.3",
+    "react": "^0.14.0",
     "react-bootstrap": "0.23.5",
+    "react-dom": "^0.14.0",
     "rimraf": "^2.4.0",
     "standard": "^4.3.2",
     "uglify-js": "^2.4.23"


### PR DESCRIPTION
### Summary

- update `react 0.14`
- add `react-dom 0.14`
- `s/React.render/ReactDOM.render`
- `s/React.findDOMNode/ReactDOM.findDOMNode`

This is a breaking change.
I recommend that you release at least as a minor version upgrade.

### Note

https://github.com/react-bootstrap/react-bootstrap v0.27.x supports for `react 0.14`. I tried that in rsg, some failure has occurred.

Warn get out, but the work still version (0.23.5). Thus, react-bootstrap It would be better to work later.

thanks