### PR TITLE
Bugfix: Windows support

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "start": "npm run styleguide && npm run serve",
-    "styleguide": "rsg 'components/**/*.js'",
+    "styleguide": "rsg \"components/**/*.js\"",
     "serve": "serve ./styleguide"
   },
   "dependencies": {

--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -9,6 +9,7 @@ var glob = require('glob')
 var mustache = require('mustache')
 var reactDocGen = require('react-docgen')
 var watchify = require('watchify')
+var slash = require('slash')
 
 /**
  * React Styleguide Generator
@@ -278,7 +279,7 @@ RSG.prototype.createContentsFile = function () {
   var dest = this.opts.output + '/src/contents.js'
   var data = this.input.map(function (file) {
     self.log.debug({ file: file }, 'styleguide input file')
-    return "require('" + file + "')"
+    return "require('" + slash(file) + "')"
   })
 
   data = 'module.exports = [' + data.join(',') + ']'

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "object-assign": "^4.0.1",
     "react-docgen": "^2.0.0",
     "react-simpletabs": "matthewgertner/react-simpletabs",
+    "slash": "^1.0.0",
     "watchify": "^3.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
On Windows machines the generator fails badly.

### Main Problem
Path problems in lib/rsg.js (l. 279-284):
```javascript
var data = this.input.map(function (file) {
  self.log.debug({ file: file }, 'styleguide input file')
  return "require('" + file + "')"
})

data = 'module.exports = [' + data.join(',') + ']'
```
Joining the array results in wrong escaping of windows path (C:\\\\tmp\\\\xyz becomes C:\tmp\xyz). Using [slash](https://github.com/sindresorhus/slash) solves this issue.

### Fixing the example project 
The example won't work since no styleguide components are found due to this command in package.json: `rsg 'components/**/*.js'`. The offending part for windows are the single quotes around   `components/**/*.js`. Leaving them out or using double quotes solves this issue.
