### PR TITLE
Fix CLI usage of watch

### DIFF
--- a/bin/rsg
+++ b/bin/rsg
@@ -51,6 +51,8 @@ var log
       log.info({ outputDir: this.opts.output}, 'Styleguide generation complete')
     }
 
-    process.exit(0)
+    if (!opts.watch) {
+      process.exit(0)
+    }
   })
 })()


### PR DESCRIPTION
Currently when using the CLI and `--watch`, the process exits after the first generation. That was not what I would expect. :)

This fixes it.