### PR TITLE
Classify RSG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 styleguide
+tmp

--- a/README.md
+++ b/README.md
@@ -170,49 +170,46 @@ Examples:
 #### Gulp
 
 ``` js
-var gulp = require('gulp')
-var RSG = require('react-styleguide-generator')
+const gulp = require('gulp')
+const rsg = require('react-styleguide-generator').rsg
 
 gulp.task('styleguide', function (done) {
-  var rsg = RSG('example/**/*.js', {
+  rsg('example/**/*.js', {
     output: 'path/to/dir',
     files: ['a.css', 'a.js']
-  })
-
-  rsg.generate(function (err) {
-    if (err) {
-      console.error(String(err))
-    }
-
-    done()
-  })
+  }).generate()
+    .then(() => done())
+    .catch(err => {
+      console.error(err)
+      done()
+    })
 })
 ```
 
 #### Grunt
 
 ``` js
-var RSG = require('react-styleguide-generator')
+const rsg = require('react-styleguide-generator').rsg
 
 grunt.registerTask('rsg', 'React style guide', function () {
-  var done = this.async()
+  const done = this.async()
 
   try {
-    var conf = grunt.config.get('rsg')
+    const conf = grunt.config.get('rsg')
 
-    RSG(conf.input, {
+    rsg(conf.input, {
       config: conf.configFile,
       watch: false,
       verbose: true
-    }).generate(function (err) {
-      if (err) {
-          grunt.log.error('Error: ' + err + ' ' + err.stack())
-          return done(false)
-      }
-
-      grunt.log.ok('react styleguide generation complete')
-      done()
-    })
+    }).generate()
+      .then(() => {
+        grunt.log.ok('react styleguide generation complete')
+        done()
+      })
+      .catch(err => {
+        grunt.log.error('Error: ' + err + ' ' + err.stack())
+        done(false)
+      })
   } catch (e) {
     grunt.log.error('Error: ' + e + ' ' + e.stack)
     done(false)
@@ -357,7 +354,7 @@ Default: `false`
 
 Enables `watchify` for when the `input` files change, speeding up rebuild time.
 
-### rsg.generate([callback])
+### rsg.generate()
 
 Generate the files and their dependencies into a styleguide output.
 

--- a/bin/rsg
+++ b/bin/rsg
@@ -1,58 +1,60 @@
 #!/usr/bin/env node
 
-var RSG = require('../lib/rsg')
-var argv = require('minimist')(process.argv.slice(2))
-var log
+const fs = require('fs')
+const path = require('path')
+const minimist = require('minimist')
+const argv = minimist(process.argv.slice(2))
+const rsg = require('../lib/rsg').rsg
+const logger = require('../lib/logger')
+const log = logger('bin', { debug: true })
 
-!(function () {
-  if (!argv._[0] || argv.h || argv.help) {
-    return require('fs').createReadStream(require('path').resolve(__dirname, 'usage.txt'))
-      .pipe(process.stdout)
-      .on('close', function () { process.exit(1) })
+if (!argv._[0] || argv.h || argv.help) {
+  return fs.createReadStream(path.resolve(__dirname, 'usage.txt'))
+    .pipe(process.stdout)
+    .on('close', () => process.exit(1))
+}
+
+if (argv.V || argv.version) {
+  return console.log(require('../package.json').version)
+}
+
+const opts = {
+  output: argv.o || argv.output,
+  title: argv.t || argv.title,
+  root: argv.r || argv.root,
+  pushstate: argv.p || argv.pushstate,
+  files: argv.f || argv.files,
+  config: argv.c || argv.config,
+  watch: argv.w || argv.watch,
+  verbose: argv.v || argv.verbose
+}
+
+// removing falsy fields from an opts
+Object.keys(opts).forEach(name => {
+  if (!opts[name]) {
+    delete opts[name]
   }
+})
 
-  if (argv.V || argv.version) {
-    return console.log(require('../package.json').version)
-  }
+// convert files to array
+// 'a.js, b.js' -> ['a.js', 'b.js']
+if (opts.files) {
+  opts.files = opts.files.split(',').map(part => part.trim())
+}
 
-  var opts = {
-    output: argv.o || argv.output,
-    title: argv.t || argv.title,
-    root: argv.r || argv.root,
-    pushstate: argv.p || argv.pushstate,
-    files: argv.f || argv.files,
-    config: argv.c || argv.config,
-    watch: argv.w || argv.watch,
-    verbose: argv.v || argv.verbose
-  }
-
-  log = require('../lib/logger')('bin', { debug: true })
-
-  // removing falsy fields from an opts
-  Object.keys(opts).forEach(function (name) {
-    if (!opts[name]) {
-      delete opts[name]
-    }
-  })
-
-  // convert files to array
-  // 'a.js, b.js' -> ['a.js', 'b.js']
-  if (opts.files) {
-    opts.files = opts.files.split(',').map(function (part) { return part.trim() })
-  }
-
-  RSG(argv._[0], opts).generate(function (err) {
-    if (err) {
-      log.error(err)
-      process.exit(1)
-    }
-
+rsg(argv._[0], opts)
+  .generate()
+  .then(() => {
     if (argv.v || argv.verbose) {
-      log.info({ outputDir: this.opts.output}, 'Styleguide generation complete')
+      log.info({
+        outputDir: this.opts.output
+      }, 'Styleguide generation complete')
     }
 
     if (!opts.watch) {
       process.exit(0)
     }
+  }).catch(err => {
+    log.error(err)
+    process.exit(1)
   })
-})()

--- a/lib/fixtures/index.html.mustache
+++ b/lib/fixtures/index.html.mustache
@@ -27,7 +27,7 @@
       }
 
       window.RSG = {
-          propMetas: {{{propMetas}}}
+        propMetas: {{{propMetas}}}
       }
 
     </script>

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,9 +1,9 @@
 const bunyan = require('bunyan')
 
-module.exports = function (section_name, opts) {
+module.exports = (section_name, opts) => {
   opts = opts || {}
 
-  var logOpts = {
+  const logOpts = {
     name: 'rsg' + '/' + section_name,
     stream: process.stdout,
     level: 'error',

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,18 +1,8 @@
 const bunyan = require('bunyan')
 
-module.exports = (section_name, opts) => {
-  opts = opts || {}
-
-  const logOpts = {
-    name: 'rsg' + '/' + section_name,
-    stream: process.stdout,
-    level: 'error',
-    serializers: bunyan.stdSerializers
-  }
-
-  if (opts.debug) {
-    logOpts.level = 'debug'
-  }
-
-  return bunyan.createLogger(logOpts)
-}
+module.exports = (section, opts = {}) => bunyan.createLogger({
+  name: 'rsg' + '/' + section,
+  stream: process.stdout,
+  level: opts.debug ? 'debug' : 'error',
+  serializers: bunyan.stdSerializers
+})

--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -1,358 +1,339 @@
 require('babel-register')
 
-var path = require('path')
-var fs = require('fs-extra')
-var browserify = require('browserify')
-var babelify = require('babelify')
-var glob = require('glob')
-var mustache = require('mustache')
-var reactDocGen = require('react-docgen')
-var watchify = require('watchify')
-var slash = require('slash')
+const path = require('path')
+const fs = require('fs-extra')
+const browserify = require('browserify')
+const babelify = require('babelify')
+const glob = require('glob')
+const mustache = require('mustache')
+const reactDocGen = require('react-docgen')
+const watchify = require('watchify')
+const slash = require('slash')
+const copy = require('./utils').copy
 
-/**
- * React Styleguide Generator
- *
- * @class
- * @param {string} input
- * @param {Object} opts
- * @param {string=} opts.output
- * @param {string=} opts.title
- * @param {string=|Object} opts.config
- * @param {string=} opts.root
- * @param {boolean=} opts.pushstate
- * @param {string[]=} opts.files
- * @param {Object=} opts.babelConfig
- * @param {Object=} opts.browserifyConfig
- * @param {Object=} opts.reactDocgen
- */
-function RSG (input, opts) {
-  opts = opts || {}
+class RSG {
+  /**
+   * React Styleguide Generator
+   *
+   * @class
+   * @param {string} input
+   * @param {Object} opts
+   * @param {string=} opts.output
+   * @param {string=} opts.title
+   * @param {string=|Object} opts.config
+   * @param {string=} opts.root
+   * @param {boolean=} opts.pushstate
+   * @param {string[]=} opts.files
+   * @param {Object=} opts.babelConfig
+   * @param {Object=} opts.browserifyConfig
+   * @param {Object=} opts.reactDocgen
+   */
+  constructor (input, opts) {
+    opts = opts || {}
 
-  this.log = require('./logger')('rsg-lib', { debug: opts.verbose || false })
+    this.log = require('./logger')('rsg-lib', { debug: opts.verbose || false })
 
-  var config
+    let config
 
-  // If feeding in a direct config object
-  if (opts.config !== null && typeof opts.config === 'object') {
-    config = opts.config
-  } else {
-    config = this.readConfig(opts.config)
+    // If feeding in a direct config object
+    if (opts.config !== null && typeof opts.config === 'object') {
+      config = opts.config
+    } else {
+      config = this.readConfig(opts.config)
+    }
+
+    opts = Object.assign(config, opts)
+
+    opts.output = path.resolve(process.cwd(), (opts.output || 'styleguide').replace(/\/+$/, ''))
+    opts.title = opts.title || 'Style Guide'
+    opts.root = opts.root ? path.normalize('/' + opts.root.replace(/\/+$/, '')) : null
+    opts.pushstate = opts.pushstate || false
+    opts.files = opts.files || []
+    opts.babelConfig = opts.babelConfig || null
+    opts.browserifyConfig = Object.assign({ debug: true }, opts.browserifyConfig, { standalone: 'Contents' })
+
+    this.input = glob.sync(input, { realpath: true })
+
+    opts['reactDocgen'] = opts['reactDocgen'] || {}
+
+    if (!opts['reactDocgen'].files) {
+      opts['reactDocgen'].files = [input]
+    }
+
+    this.opts = opts
+    this.reactVersion = require('react').version
+
+    // stores prop documentation generated from react-docgen
+    this.reactPropMetas = {}
+
+    // files to parse for react-docgen
+    this.reactDocGenFiles = this.getReactPropDocFiles()
+
+    // Cache of file modification times so we're not re-parsing
+    // files that have not changed in react-docgen for perf
+    this.reactDocGenCache = {}
+
+    // has the first-pass of parsing happened?
+    this.reactDocGenInit = false
+
+    // Cached files to include into the styleguide app
+    this.cssFiles = this.extractFiles('.css')
+    this.jsFiles = this.extractFiles('.js')
+
+    this.appTemplate = fs.readFileSync(path.resolve(__dirname, './fixtures/index.html.mustache'), 'utf-8')
   }
 
-  opts = Object.assign(config, opts)
+  /**
+   * @param {string=} file
+   * @returns {Object}
+   */
+  readConfig (file) {
+    file = file === undefined ? 'styleguide.json' : file
 
-  opts.output = path.resolve(process.cwd(), (opts.output || 'styleguide').replace(/\/+$/, ''))
-  opts.title = opts.title || 'Style Guide'
-  opts.root = opts.root ? path.normalize('/' + opts.root.replace(/\/+$/, '')) : null
-  opts.pushstate = opts.pushstate || false
-  opts.files = opts.files || []
-  opts.babelConfig = opts.babelConfig || null
-  opts.browserifyConfig = Object.assign({ debug: true }, opts.browserifyConfig, { standalone: 'Contents' })
+    if (!file) { return {} }
 
-  this.input = glob.sync(input, { realpath: true })
+    const src = process.cwd() + '/' + file
 
-  opts['reactDocgen'] = opts['reactDocgen'] || {}
+    this.log.info({ configFile: src }, 'Reading config file')
 
-  if (!opts['reactDocgen'].files) {
-    opts['reactDocgen'].files = [input]
+    return fs.existsSync(src) ? fs.readJsonSync(src) : {}
   }
 
-  this.opts = opts
-  this.reactVersion = require('react').version
+  /**
+   * Generates the files to process for react-docgen
+   */
+  getReactPropDocFiles () {
+    const files = this.opts['reactDocgen'].files
+    const fileList = []
 
-  // stores prop documentation generated from react-docgen
-  this.reactPropMetas = {}
-
-  // files to parse for react-docgen
-  this.reactDocGenFiles = this.getReactPropDocFiles()
-
-  // Cache of file modification times so we're not re-parsing
-  // files that have not changed in react-docgen for perf
-  this.reactDocGenCache = {}
-
-  // has the first-pass of parsing happened?
-  this.reactDocGenInit = false
-
-  // Cached files to include into the styleguide app
-  this.cssFiles = this.extractFiles('.css')
-  this.jsFiles = this.extractFiles('.js')
-
-  this.appTemplate = fs.readFileSync(path.resolve(__dirname, './fixtures/index.html.mustache'), 'utf-8')
-}
-
-/**
- * @param {string=} file
- * @returns {Object}
- */
-RSG.prototype.readConfig = function (file) {
-  file = file === undefined ? 'styleguide.json' : file
-
-  if (!file) { return {} }
-
-  var src = process.cwd() + '/' + file
-
-  this.log.info({ configFile: src }, 'Reading config file')
-
-  return fs.existsSync(src) ? fs.readJsonSync(src) : {}
-}
-
-/**
- * Generates the files to process for react-docgen
- */
-RSG.prototype.getReactPropDocFiles = function () {
-  var files = this.opts['reactDocgen'].files
-  var fileList = []
-
-  files.forEach(function (file) {
-    fileList = fileList.concat(glob.sync(file, { realpath: true }))
-  })
-
-  // remove dupes
-  return fileList.filter(function (elem, pos) {
-    return fileList.indexOf(elem) === pos
-  })
-}
-
-/**
- * Generates propType metadata using react-docgen
- * @returns {Promise}
- */
-RSG.prototype.genReactPropDoc = function () {
-  var self = this
-
-  return new Promise(function (resolve, reject) {
-    self.reactDocGenFiles.forEach(function (file) {
-      try {
-        var fileStat = fs.statSync(file)
-
-        // If we do not have the file in our cache, or the mod time has changed, parse the file
-        if (!self.reactDocGenCache[file] || self.reactDocGenCache[file] && self.reactDocGenCache[file] !== fileStat.mtime) {
-          var srcData = fs.readFileSync(file)
-
-          var propMetadata = reactDocGen.parse(srcData)
-
-          var displayName = propMetadata.displayName
-
-          if (displayName) {
-            // only check for duplicate displayNames on the first pass
-            // subsequent passes, we can assume we're regenerating the prop information
-            if (self.reactPropMetas[displayName] && !self.reactDocGenInit) {
-              reject(new Error('displayName already exists: ' + displayName))
-            } else {
-              self.reactPropMetas[displayName] = propMetadata
-            }
-          }
-
-          self.reactDocGenCache[file] = fileStat.mtime
-        }
-      } catch (e) {
-        // self.log.error(e, 'react-docgen error processing: %s', file)
-      }
+    files.forEach(file => {
+      glob.sync(file, { realpath: true }).forEach(f => fileList.push(f))
     })
 
-    self.reactDocGenInit = true
+    // remove dupes
+    return fileList.filter((elem, pos) => fileList.indexOf(elem) === pos)
+  }
 
-    resolve()
-  })
-}
+  /**
+   * Generates propType metadata using react-docgen
+   * @returns {Promise}
+   */
+  genReactPropDoc () {
+    return new Promise((resolve, reject) => {
+      this.reactDocGenFiles.forEach(file => {
+        try {
+          const fileStat = fs.statSync(file)
 
-/**
- * @param {string} src
- * @param {string} dest
- * @returns {Promise}
- */
-RSG.prototype.copy = function (src, dest) {
-  return new Promise(function (resolve, reject) {
-    fs.copy(src, dest, function (err) {
-      if (err) { return reject(err) }
+          // If we do not have the file in our cache, or the mod time has changed, parse the file
+          if (!this.reactDocGenCache[file] ||
+              this.reactDocGenCache[file] && this.reactDocGenCache[file] !== fileStat.mtime) {
+            const srcData = fs.readFileSync(file)
+            const propMetadata = reactDocGen.parse(srcData)
+            const displayName = propMetadata.displayName
+
+            if (displayName) {
+              // only check for duplicate displayNames on the first pass
+              // subsequent passes, we can assume we're regenerating the prop information
+              if (this.reactPropMetas[displayName] && !this.reactDocGenInit) {
+                reject(new Error('displayName already exists: ' + displayName))
+              } else {
+                this.reactPropMetas[displayName] = propMetadata
+              }
+            }
+
+            this.reactDocGenCache[file] = fileStat.mtime
+          }
+        } catch (e) {
+          // this.log.error(e, 'react-docgen error processing: %s', file)
+        }
+      })
+
+      this.reactDocGenInit = true
+
       resolve()
     })
-  })
-}
+  }
 
-/**
- * @returns {Promise}
- */
-RSG.prototype.copyAppFiles = function () {
-  var src = path.resolve(__dirname, '../dist')
-  var dest = this.opts.output + '/src'
+  /**
+   * @returns {Promise}
+   */
+  copyAppFiles () {
+    const src = path.resolve(__dirname, '../dist')
+    const dest = this.opts.output + '/src'
 
-  return this.copy(src, dest)
-}
+    return copy(src, dest)
+  }
 
-/**
- * @returns {Promise}
- */
-RSG.prototype.copyOptsFiles = function () {
-  var copy = this.copy
-  var output = this.opts.output
+  /**
+   * @returns {Promise}
+   */
+  copyOptsFiles () {
+    const output = this.opts.output
+    const files = this.opts.files.filter(file => fs.existsSync(file))
 
-  var files = this.opts.files.filter(function (file) {
-    return fs.existsSync(file)
-  })
+    return Promise.all(
+      files.map(file => copy(file, `${output}/files/${path.basename(file)}`))
+    )
+  }
 
-  return Promise.all(
-    files.map(function (file) {
-      var dest = output + '/files/' + path.basename(file)
-      return copy(file, dest)
-    })
-  )
-}
+  /**
+   * @param {string} ext
+   * @returns {string[]}
+   */
+  extractFiles (ext) {
+    return this.opts.files
+      .filter(file => path.extname(file) === ext)
+      .map(file => {
+        // linter had issues with a ternary operator
+        // resulting in 'Infix operators must be spaced'
+        // unsure how it passed on master
+        if (fs.existsSync(file)) {
+          return `files/${path.basename(file)}`
+        }
 
-/**
- * @param {string} ext
- * @returns {string[]}
- */
-RSG.prototype.extractFiles = function (ext) {
-  return this.opts.files
-    .filter(function (file) { return path.extname(file) === ext })
-    .map(function (file) {
-      // linter had issues with a ternary operator
-      // resulting in 'Infix operators must be spaced'
-      // unsure how it passed on master
-      if (fs.existsSync(file)) {
-        return ('files/' + path.basename(file))
-      }
-
-      return file
-    })
-}
-
-/**
- * @returns {Promise}
- */
-RSG.prototype.createHtmlFile = function () {
-  this.genReactPropDoc().then(function () {
-    var data = Object.assign({}, this.opts, {
-      hashbang: this.opts.pushstate ? 'false' : 'true',
-      reactVersion: this.reactVersion,
-      cssFils: this.cssFiles,
-      jsFils: this.jsFiles,
-      propMetas: JSON.stringify(this.reactPropMetas)
-    })
-
-    var dest = this.opts.output + '/index.html'
-    var rendered = mustache.render(this.appTemplate, data)
-
-    return new Promise(function (resolve, reject) {
-      fs.outputFile(dest, rendered, function (err) {
-        if (err) { return reject(err) }
-        resolve()
+        return file
       })
-    })
-  }.bind(this))
-}
+  }
 
-/**
- * @returns {Promise}
- */
-RSG.prototype.createReactFile = function () {
-  var dest = this.opts.output + '/src/react_' + this.reactVersion + '.js'
-
-  if (fs.existsSync(dest)) { return Promise.resolve() }
-
-  var b = browserify({ debug: true })
-    .require('react')
-    .require('react-dom')
-
-  return new Promise(function (resolve, reject) {
-    b.bundle(function (err, buffer) {
-      if (err) { return reject(err) }
-
-      fs.outputFile(dest, buffer, function (outputFileErr) {
-        if (outputFileErr) { return reject(outputFileErr) }
-        resolve()
+  /**
+   * @returns {Promise}
+   */
+  createHtmlFile () {
+    this.genReactPropDoc().then(() => {
+      const data = Object.assign({}, this.opts, {
+        hashbang: this.opts.pushstate ? 'false' : 'true',
+        reactVersion: this.reactVersion,
+        cssFils: this.cssFiles,
+        jsFils: this.jsFiles,
+        propMetas: JSON.stringify(this.reactPropMetas)
       })
-    })
-  })
-}
 
-/**
- * @returns {Promise}
- */
-RSG.prototype.createContentsFile = function () {
-  var self = this
-  var contentsInter = this.opts.output + '/src/contents-inter.js'
-  var dest = this.opts.output + '/src/contents.js'
-  var data = this.input.map(function (file) {
-    self.log.debug({ file: file }, 'styleguide input file')
-    return "require('" + slash(file) + "')"
-  })
+      const dest = this.opts.output + '/index.html'
+      const rendered = mustache.render(this.appTemplate, data)
 
-  data = 'module.exports = [' + data.join(',') + ']'
-  fs.outputFileSync(contentsInter, data)
-
-  var b = browserify(contentsInter, self.opts.browserifyConfig)
-
-  b.transform(babelify.configure(self.opts.babelConfig))
-    .external('react')
-    .external('react-dom')
-
-  function distContentsFile () {
-    return new Promise(function (resolve, reject) {
-      b.bundle(function (err, buffer) {
-        if (err) { return reject(err) }
-
-        fs.outputFile(dest, buffer, function (outputFileErr) {
-          if (outputFileErr) { return reject(outputFileErr) }
-          resolve()
+      return new Promise((resolve, reject) => {
+        fs.outputFile(dest, rendered, err => {
+          if (err) {
+            reject(err)
+          } else {
+            resolve()
+          }
         })
       })
     })
   }
 
-  if (self.opts.watch) {
-    self.log.info('styleguide watch mode enabled')
+  /**
+   * @returns {Promise}
+   */
+  createReactFile () {
+    const dest = `${this.opts.output}/src/react_${this.reactVersion}.js`
 
-    b = watchify(b)
+    if (fs.existsSync(dest)) {
+      return Promise.resolve()
+    }
 
-    b.on('update', function () {
-      self.log.info('styleguide updating')
+    const b = browserify({ debug: true })
+      .require('react')
+      .require('react-dom')
 
-      Promise.all([
-        self.createHtmlFile(),
-        distContentsFile()
-      ]).then(function () {
-      }).catch(function (err) {
-        self.log.error(err, 'browserify update error')
+    return new Promise((resolve, reject) => {
+      b.bundle((err, buffer) => {
+        if (err) {
+          return reject(err)
+        }
+
+        fs.outputFile(dest, buffer, outputFileErr => {
+          if (outputFileErr) {
+            reject(outputFileErr)
+          } else {
+            resolve()
+          }
+        })
       })
-    })
-
-    b.on('error', function (err) {
-      self.log.error(err, 'browserify error')
-    })
-
-    b.on('time', function (time) {
-      self.log.info('styleguide rebundled in ' + time + 'ms')
     })
   }
 
-  return distContentsFile()
-}
+  /**
+   * @returns {Promise}
+   */
+  createContentsFile () {
+    const contentsInter = `${this.opts.output}/src/contents-inter.js`
+    const dest = `${this.opts.output}/src/contents.js`
+    let data = this.input.map(file => {
+      this.log.debug({ file: file }, 'styleguide input file')
+      return `require('${slash(file)}')`
+    })
 
-/**
- * @param {Function=} cb
- * @returns {Promise}
- */
-RSG.prototype.generate = function (cb) {
-  cb = cb ? cb.bind(this) : function () {}
+    data = 'module.exports = [' + data.join(',') + ']'
+    fs.outputFileSync(contentsInter, data)
 
-  return Promise
-    .all([
+    let b = browserify(contentsInter, this.opts.browserifyConfig)
+
+    b.transform(babelify.configure(this.opts.babelConfig))
+      .external('react')
+      .external('react-dom')
+
+    function distContentsFile () {
+      return new Promise((resolve, reject) => {
+        b.bundle((err, buffer) => {
+          if (err) {
+            return reject(err)
+          }
+
+          fs.outputFile(dest, buffer, outputFileErr => {
+            if (outputFileErr) {
+              reject(outputFileErr)
+            } else {
+              resolve()
+            }
+          })
+        })
+      })
+    }
+
+    if (this.opts.watch) {
+      this.log.info('styleguide watch mode enabled')
+
+      b = watchify(b)
+
+      b.on('update', () => {
+        this.log.info('styleguide updating')
+
+        Promise.all([
+          this.createHtmlFile(),
+          distContentsFile()
+        ]).catch(err => {
+          this.log.error(err, 'browserify update error')
+        })
+      })
+
+      b.on('error', err => {
+        this.log.error(err, 'browserify error')
+      })
+
+      b.on('time', time => {
+        this.log.info('styleguide rebundled in ' + time + 'ms')
+      })
+    }
+
+    return distContentsFile()
+  }
+
+  /**
+   * @returns {Promise}
+   */
+  generate () {
+    return Promise.all([
       this.copyAppFiles(),
       this.copyOptsFiles(),
       this.createHtmlFile(),
       this.createReactFile(),
       this.createContentsFile()
     ])
-    .then(function () { cb() })
-    .catch(function (err) {
-      this.log.error(err)
-      cb(err)
-    }.bind(this))
+  }
 }
 
-module.exports = function (input, opts) {
+module.exports = (input, opts) => {
   return new RSG(input, opts)
 }

--- a/lib/rsg.js
+++ b/lib/rsg.js
@@ -10,6 +10,7 @@ const reactDocGen = require('react-docgen')
 const watchify = require('watchify')
 const slash = require('slash')
 const copy = require('./utils').copy
+const logger = require('./logger')
 
 class RSG {
   /**
@@ -28,10 +29,8 @@ class RSG {
    * @param {Object=} opts.browserifyConfig
    * @param {Object=} opts.reactDocgen
    */
-  constructor (input, opts) {
-    opts = opts || {}
-
-    this.log = require('./logger')('rsg-lib', { debug: opts.verbose || false })
+  constructor (input, opts = {}) {
+    this.log = logger('rsg-lib', { debug: opts.verbose || false })
 
     let config
 
@@ -87,9 +86,7 @@ class RSG {
    * @param {string=} file
    * @returns {Object}
    */
-  readConfig (file) {
-    file = file === undefined ? 'styleguide.json' : file
-
+  readConfig (file = 'styleguide.json') {
     if (!file) { return {} }
 
     const src = process.cwd() + '/' + file
@@ -135,7 +132,7 @@ class RSG {
               // only check for duplicate displayNames on the first pass
               // subsequent passes, we can assume we're regenerating the prop information
               if (this.reactPropMetas[displayName] && !this.reactDocGenInit) {
-                reject(new Error('displayName already exists: ' + displayName))
+                reject(new Error(`displayName already exists: ${displayName}`))
               } else {
                 this.reactPropMetas[displayName] = propMetadata
               }
@@ -313,7 +310,7 @@ class RSG {
       })
 
       b.on('time', time => {
-        this.log.info('styleguide rebundled in ' + time + 'ms')
+        this.log.info(`styleguide rebundled in ${time}ms`)
       })
     }
 
@@ -334,6 +331,8 @@ class RSG {
   }
 }
 
-module.exports = (input, opts) => {
+module.exports = RSG
+
+module.exports.rsg = (input, opts) => {
   return new RSG(input, opts)
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,11 +1,28 @@
-module.exports = {
-  getDisplayName: function (component) {
-    if (component && component.name === 'RadiumEnhancer') {
-      return component.displayName.replace(/Radium\((.*)\)/, '$1')
-    } else if (component) {
-      return component.displayName
-    }
+const fs = require('fs-extra')
 
-    return null
+module.exports.getDisplayName = component => {
+  if (component && component.name === 'RadiumEnhancer') {
+    return component.displayName.replace(/Radium\((.*)\)/, '$1')
+  } else if (component) {
+    return component.displayName
   }
+
+  return null
+}
+
+/**
+ * @param {string} src
+ * @param {string} dest
+ * @returns {Promise}
+ */
+module.exports.copy = (src, dest) => {
+  return new Promise((resolve, reject) => {
+    fs.copy(src, dest, err => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve()
+      }
+    })
+  })
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "browserify_transforms": "[ babelify --presets [ es2015 react ] --plugins [ add-module-exports transform-class-properties ] ]"
   },
   "scripts": {
-    "test": "standard && mocha test/**/*.js",
+    "test": "standard && ava",
     "prod": "npm run clean && npm run build",
     "build": "npm run build:css && npm run build:js",
     "build:css": "postcss $npm_package_config_postcss_plugins --output dist/app.css app/index.css",
@@ -95,12 +95,12 @@
     "watchify": "^3.7.0"
   },
   "devDependencies": {
+    "ava": "^0.17.0",
     "babel-eslint": "^6.1.2",
     "cssnano": "^3.8.1",
     "gh-pages": "^0.4.0",
     "highlight.js": "^8.6.0",
     "marked": "^0.3.3",
-    "mocha": "^2.2.5",
     "page": "1.6.3",
     "postcss-cli": "^2.6.0",
     "postcss-cssnext": "^2.9.0",

--- a/test/rsg.js
+++ b/test/rsg.js
@@ -1,8 +1,6 @@
-/* global describe, it, after */
-
-const assert = require('assert')
 const path = require('path')
 const fs = require('fs-extra')
+const test = require('ava')
 const rsg = require('../lib/rsg').rsg
 
 const INPUT_FILE = 'example/components/**/*.js'
@@ -22,6 +20,7 @@ function RSG (input, opts) {
         'react'
       ],
       plugins: [
+        'add-module-exports',
         'transform-class-properties'
       ]
     },
@@ -40,191 +39,161 @@ function getRealPath (file) {
   return path.resolve(process.cwd(), file)
 }
 
-describe('RSG', function () {
-  after(() => {
-    fs.removeSync(TMP_DIR)
+test.after(() => {
+  fs.removeSync(TMP_DIR)
+})
+
+test('should throw an exception when the value is not present', t => {
+  t.throws(RSG.bind(), Error)
+})
+
+test('should be an array', t => {
+  const rsg = RSG(INPUT_FILE)
+  t.true(Array.isArray(rsg.input))
+})
+
+test('should be a realpath', t => {
+  const rsg = RSG(INPUT_FILE)
+  t.true(rsg.input.every(file => getRealPath(file)))
+})
+
+test('should default to "styleguide"', t => {
+  const rsg = RSG(INPUT_FILE, { output: undefined })
+  t.is(rsg.opts.output, getRealPath('styleguide'))
+})
+
+test('should be a "Foo"', t => {
+  const rsg = RSG(INPUT_FILE, { output: 'Foo' })
+  t.is(rsg.opts.output, getRealPath('Foo'))
+})
+
+test('should default to "Style Guide"', t => {
+  const rsg = RSG(INPUT_FILE, { title: undefined })
+  t.is(rsg.opts.title, 'Style Guide')
+})
+
+test('should be a "Foo"', t => {
+  const rsg = RSG(INPUT_FILE, { title: 'Foo' })
+  t.is(rsg.opts.title, 'Foo')
+})
+
+test('should default to null', t => {
+  const rsg = RSG(INPUT_FILE, { root: undefined })
+  t.is(rsg.opts.root, null)
+})
+
+test('should be a "foo"', t => {
+  const rsg = RSG(INPUT_FILE, { root: 'foo' })
+  t.is(rsg.opts.root, '/foo')
+})
+
+test('should default to false', t => {
+  const rsg = RSG(INPUT_FILE, { pushstate: undefined })
+  t.false(rsg.opts.pushstate)
+})
+
+test('should be a true', t => {
+  const rsg = RSG(INPUT_FILE, { pushstate: true })
+  t.true(rsg.opts.pushstate)
+})
+
+test('should default to []', t => {
+  const rsg = RSG(INPUT_FILE, { files: undefined })
+  t.deepEqual(rsg.opts.files, [])
+})
+
+test('should be the files', t => {
+  const files = ['a.css', 'a.js']
+  const rsg = RSG(INPUT_FILE, { files: files })
+  t.deepEqual(rsg.opts.files, files)
+})
+
+test('should default to null', t => {
+  const rsg = RSG(INPUT_FILE, { babelConfig: undefined })
+  t.is(rsg.opts.babelConfig, null)
+})
+
+test('should be an object', t => {
+  const babelConfig = {
+    presets: [
+      'es2015',
+      'react'
+    ],
+    plugins: [
+      'transform-class-properties'
+    ]
+  }
+  const rsg = RSG(INPUT_FILE, { babelConfig })
+  t.deepEqual(rsg.opts.babelConfig, babelConfig)
+})
+
+test('should default to { standalone: \'Contents\', debug: true }', t => {
+  const browserifyConfig = {
+    debug: true,
+    standalone: 'Contents'
+  }
+  const rsg = RSG(INPUT_FILE, {
+    browserifyConfig
   })
+  t.deepEqual(rsg.opts.browserifyConfig, browserifyConfig)
+})
 
-  describe('input', function () {
-    it('should throw an exception when the value is not present', () => {
-      assert.throws(RSG.bind(), Error)
-    })
-
-    it('should be an array', () => {
-      const rsg = RSG(INPUT_FILE)
-      assert(Array.isArray(rsg.input))
-    })
-
-    it('should be a realpath', () => {
-      const rsg = RSG(INPUT_FILE)
-      assert(rsg.input.every(file => getRealPath(file)))
-    })
-  })
-
-  describe('opts.output', function () {
-    it('should default to "styleguide"', () => {
-      const rsg = RSG(INPUT_FILE, { output: undefined })
-      assert.equal(rsg.opts.output, getRealPath('styleguide'))
-    })
-
-    it('should be a "Foo"', () => {
-      const rsg = RSG(INPUT_FILE, { output: 'Foo' })
-      assert.equal(rsg.opts.output, getRealPath('Foo'))
-    })
-  })
-
-  describe('opts.title', function () {
-    it('should default to "Style Guide"', () => {
-      const rsg = RSG(INPUT_FILE, { title: undefined })
-      assert.equal(rsg.opts.title, 'Style Guide')
-    })
-
-    it('should be a "Foo"', () => {
-      const rsg = RSG(INPUT_FILE, { title: 'Foo' })
-      assert.equal(rsg.opts.title, 'Foo')
-    })
-  })
-
-  describe('opts.root', function () {
-    it('should default to null', () => {
-      const rsg = RSG(INPUT_FILE, { root: undefined })
-      assert.equal(rsg.opts.root, null)
-    })
-
-    it('should be a "foo"', () => {
-      const rsg = RSG(INPUT_FILE, { root: 'foo' })
-      assert.equal(rsg.opts.root, '/foo')
-    })
-  })
-
-  describe('opts.pushstate', function () {
-    it('should default to false', () => {
-      const rsg = RSG(INPUT_FILE, { pushstate: undefined })
-      assert.equal(rsg.opts.pushstate, false)
-    })
-
-    it('should be a true', () => {
-      const rsg = RSG(INPUT_FILE, { pushstate: true })
-      assert.equal(rsg.opts.pushstate, true)
-    })
-  })
-
-  describe('opts.files', function () {
-    it('should default to []', () => {
-      const rsg = RSG(INPUT_FILE, { files: undefined })
-      assert.deepEqual(rsg.opts.files, [])
-    })
-
-    it('should be the files', () => {
-      const files = ['a.css', 'a.js']
-      const rsg = RSG(INPUT_FILE, { files: files })
-      assert.deepEqual(rsg.opts.files, files)
-    })
-  })
-
-  describe('opts.babelConfig', function () {
-    it('should default to null', () => {
-      const rsg = RSG(INPUT_FILE, { babelConfig: undefined })
-      assert.equal(rsg.opts.babelConfig, null)
-    })
-
-    it('should be an object', () => {
-      const babelConfig = {
-        presets: [
-          'es2015',
-          'react'
-        ],
-        plugins: [
-          'transform-class-properties'
-        ]
-      }
-      const rsg = RSG(INPUT_FILE, { babelConfig })
-      assert.deepEqual(rsg.opts.babelConfig, babelConfig)
-    })
-  })
-
-  describe('opts.browserifyConfig', function () {
-    it('should default to { standalone: \'Contents\', debug: true }', () => {
-      const browserifyConfig = {
-        standalone: 'Contents',
-        debug: true
-      }
-      const rsg = RSG(INPUT_FILE, {
-        browserifyConfig
-      })
-      assert.deepEqual(rsg.opts.browserifyConfig, browserifyConfig)
-    })
-
-    it('should merge with defaults', function () {
-      const browserifyMergedConfig = {
-        standalone: 'Contents',
-        debug: true,
-        extensions: ['', '.js', '.jsx']
-      }
-      const rsg = RSG(INPUT_FILE, {
-        browserifyConfig: {
-          extensions: ['', '.js', '.jsx']
-        }
-      })
-      assert.deepEqual(rsg.opts.browserifyConfig, browserifyMergedConfig)
-    })
-  })
-
-  describe('opts.config', function () {
-    it('should load styleguide.json', function () {
-      const rsg = RSG(INPUT_FILE, {
-        config: undefined
-      })
-      assert.equal(rsg.opts.title, 'React Style Guide')
-    })
-
-    it('should be overwritten', () => {
-      const rsg = RSG(INPUT_FILE, {
-        config: undefined,
-        title: 'foo'
-      })
-      assert.equal(rsg.opts.title, 'foo')
-    })
-
-    it('should custom config file', () => {
-      const src = TMP_DIR + '/foo.json'
-      fs.outputFileSync(src, '{ "title": "foo" }')
-
-      const rsg = RSG(INPUT_FILE, {
-        config: src
-      })
-      assert.equal(rsg.opts.title, 'foo')
-      fs.removeSync(src)
-    })
-  })
-
-  describe('#generate', function () {
-    // this test is too heavy...
-    this.timeout(60000)
-
-    const opts = {
-      files: [
-        '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css',
-        'example/example.css'
-      ]
+test('should merge with defaults', t => {
+  const browserifyMergedConfig = {
+    debug: true,
+    standalone: 'Contents',
+    extensions: ['', '.js', '.jsx']
+  }
+  const rsg = RSG(INPUT_FILE, {
+    browserifyConfig: {
+      extensions: ['', '.js', '.jsx']
     }
-
-    const rsg = RSG(INPUT_FILE, opts)
-    const generated = rsg.generate()
-
-    it('files should exist', done => {
-      const files = [
-        'index.html',
-        'src/contents.js',
-        'src/contents-inter.js',
-        'src/react_' + rsg.reactVersion + '.js',
-        'files/example.css'
-      ].map(file => getRealPath(TMP_DIR + '/' + file))
-
-      generated.then(() => {
-        assert(files.every(file => fs.existsSync(file)))
-        done()
-      }).catch(done)
-    })
   })
+  t.deepEqual(rsg.opts.browserifyConfig, browserifyMergedConfig)
+})
+
+test('should load styleguide.json', t => {
+  const rsg = RSG(INPUT_FILE, {
+    config: undefined
+  })
+  t.is(rsg.opts.title, 'React Style Guide')
+})
+
+test('should be overwritten', t => {
+  const rsg = RSG(INPUT_FILE, {
+    config: undefined,
+    title: 'foo'
+  })
+  t.is(rsg.opts.title, 'foo')
+})
+
+test('should custom config file', t => {
+  const src = TMP_DIR + '/foo.json'
+  fs.outputFileSync(src, '{ "title": "foo" }')
+
+  const rsg = RSG(INPUT_FILE, {
+    config: src
+  })
+  t.is(rsg.opts.title, 'foo')
+  fs.removeSync(src)
+})
+
+test('files should exist', async t => {
+  const rsg = RSG(INPUT_FILE, {
+    files: [
+      '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css',
+      'example/example.css'
+    ]
+  })
+  await rsg.generate()
+
+  const files = [
+    'index.html',
+    'src/contents.js',
+    'src/contents-inter.js',
+    'src/react_' + rsg.reactVersion + '.js',
+    'files/example.css'
+  ].map(file => getRealPath(TMP_DIR + '/' + file))
+
+  t.true(files.every(file => fs.existsSync(file)))
 })

--- a/test/rsg.js
+++ b/test/rsg.js
@@ -1,19 +1,19 @@
 /* global describe, it, after */
 
-var assert = require('assert')
-var path = require('path')
-var fs = require('fs-extra')
-var _RSG = require('../lib/rsg')
+const assert = require('assert')
+const path = require('path')
+const fs = require('fs-extra')
+const rsg = require('../lib/rsg').rsg
 
-var INPUT_FILE = 'example/components/**/*.js'
-var TMP_DIR = 'tmp'
+const INPUT_FILE = 'example/components/**/*.js'
+const TMP_DIR = 'tmp'
 
 /**
  * @param {string} input
  * @param {Object=} opts
  */
 function RSG (input, opts) {
-  var baseOpts = {
+  return rsg(input, Object.assign({
     output: TMP_DIR,
     config: null,
     babelConfig: {
@@ -29,9 +29,7 @@ function RSG (input, opts) {
       standalone: 'Contents',
       debug: true
     }
-  }
-
-  return _RSG(input, Object.assign(baseOpts, opts))
+  }, opts))
 }
 
 /**
@@ -43,95 +41,95 @@ function getRealPath (file) {
 }
 
 describe('RSG', function () {
-  after(function () {
+  after(() => {
     fs.removeSync(TMP_DIR)
   })
 
   describe('input', function () {
-    it('should throw an exception when the value is not present', function () {
+    it('should throw an exception when the value is not present', () => {
       assert.throws(RSG.bind(), Error)
     })
 
-    it('should be an array', function () {
-      var rsg = RSG(INPUT_FILE)
+    it('should be an array', () => {
+      const rsg = RSG(INPUT_FILE)
       assert(Array.isArray(rsg.input))
     })
 
-    it('should be a realpath', function () {
-      var rsg = RSG(INPUT_FILE)
-      assert(rsg.input.every(function (file) { return getRealPath(file) }))
+    it('should be a realpath', () => {
+      const rsg = RSG(INPUT_FILE)
+      assert(rsg.input.every(file => getRealPath(file)))
     })
   })
 
   describe('opts.output', function () {
-    it('should default to "styleguide"', function () {
-      var rsg = RSG(INPUT_FILE, { output: undefined })
+    it('should default to "styleguide"', () => {
+      const rsg = RSG(INPUT_FILE, { output: undefined })
       assert.equal(rsg.opts.output, getRealPath('styleguide'))
     })
 
-    it('should be a "Foo"', function () {
-      var rsg = RSG(INPUT_FILE, { output: 'Foo' })
+    it('should be a "Foo"', () => {
+      const rsg = RSG(INPUT_FILE, { output: 'Foo' })
       assert.equal(rsg.opts.output, getRealPath('Foo'))
     })
   })
 
   describe('opts.title', function () {
-    it('should default to "Style Guide"', function () {
-      var rsg = RSG(INPUT_FILE, { title: undefined })
+    it('should default to "Style Guide"', () => {
+      const rsg = RSG(INPUT_FILE, { title: undefined })
       assert.equal(rsg.opts.title, 'Style Guide')
     })
 
-    it('should be a "Foo"', function () {
-      var rsg = RSG(INPUT_FILE, { title: 'Foo' })
+    it('should be a "Foo"', () => {
+      const rsg = RSG(INPUT_FILE, { title: 'Foo' })
       assert.equal(rsg.opts.title, 'Foo')
     })
   })
 
   describe('opts.root', function () {
-    it('should default to null', function () {
-      var rsg = RSG(INPUT_FILE, { root: undefined })
+    it('should default to null', () => {
+      const rsg = RSG(INPUT_FILE, { root: undefined })
       assert.equal(rsg.opts.root, null)
     })
 
-    it('should be a "foo"', function () {
-      var rsg = RSG(INPUT_FILE, { root: 'foo' })
+    it('should be a "foo"', () => {
+      const rsg = RSG(INPUT_FILE, { root: 'foo' })
       assert.equal(rsg.opts.root, '/foo')
     })
   })
 
   describe('opts.pushstate', function () {
-    it('should default to false', function () {
-      var rsg = RSG(INPUT_FILE, { pushstate: undefined })
+    it('should default to false', () => {
+      const rsg = RSG(INPUT_FILE, { pushstate: undefined })
       assert.equal(rsg.opts.pushstate, false)
     })
 
-    it('should be a true', function () {
-      var rsg = RSG(INPUT_FILE, { pushstate: true })
+    it('should be a true', () => {
+      const rsg = RSG(INPUT_FILE, { pushstate: true })
       assert.equal(rsg.opts.pushstate, true)
     })
   })
 
   describe('opts.files', function () {
-    it('should default to []', function () {
-      var rsg = RSG(INPUT_FILE, { files: undefined })
+    it('should default to []', () => {
+      const rsg = RSG(INPUT_FILE, { files: undefined })
       assert.deepEqual(rsg.opts.files, [])
     })
 
-    it('should be the files', function () {
-      var files = ['a.css', 'a.js']
-      var rsg = RSG(INPUT_FILE, { files: files })
+    it('should be the files', () => {
+      const files = ['a.css', 'a.js']
+      const rsg = RSG(INPUT_FILE, { files: files })
       assert.deepEqual(rsg.opts.files, files)
     })
   })
 
   describe('opts.babelConfig', function () {
-    it('should default to null', function () {
-      var rsg = RSG(INPUT_FILE, { babelConfig: undefined })
+    it('should default to null', () => {
+      const rsg = RSG(INPUT_FILE, { babelConfig: undefined })
       assert.equal(rsg.opts.babelConfig, null)
     })
 
-    it('should be an object', function () {
-      var babelConfig = {
+    it('should be an object', () => {
+      const babelConfig = {
         presets: [
           'es2015',
           'react'
@@ -140,41 +138,61 @@ describe('RSG', function () {
           'transform-class-properties'
         ]
       }
-      var rsg = RSG(INPUT_FILE, { babelConfig: babelConfig })
+      const rsg = RSG(INPUT_FILE, { babelConfig })
       assert.deepEqual(rsg.opts.babelConfig, babelConfig)
     })
   })
 
   describe('opts.browserifyConfig', function () {
-    it('should default to { standalone: \'Contents\', debug: true }', function () {
-      var browserifyConfig = { standalone: 'Contents', debug: true }
-      var rsg = RSG(INPUT_FILE, { browserifyConfig: undefined })
+    it('should default to { standalone: \'Contents\', debug: true }', () => {
+      const browserifyConfig = {
+        standalone: 'Contents',
+        debug: true
+      }
+      const rsg = RSG(INPUT_FILE, {
+        browserifyConfig
+      })
       assert.deepEqual(rsg.opts.browserifyConfig, browserifyConfig)
     })
 
     it('should merge with defaults', function () {
-      var browserifyMergedConfig = { standalone: 'Contents', debug: true, extensions: ['', '.js', '.jsx'] }
-      var rsg = RSG(INPUT_FILE, { browserifyConfig: { extensions: ['', '.js', '.jsx'] } })
+      const browserifyMergedConfig = {
+        standalone: 'Contents',
+        debug: true,
+        extensions: ['', '.js', '.jsx']
+      }
+      const rsg = RSG(INPUT_FILE, {
+        browserifyConfig: {
+          extensions: ['', '.js', '.jsx']
+        }
+      })
       assert.deepEqual(rsg.opts.browserifyConfig, browserifyMergedConfig)
     })
   })
 
   describe('opts.config', function () {
     it('should load styleguide.json', function () {
-      var rsg = RSG(INPUT_FILE, { config: undefined })
+      const rsg = RSG(INPUT_FILE, {
+        config: undefined
+      })
       assert.equal(rsg.opts.title, 'React Style Guide')
     })
 
-    it('should be overwritten', function () {
-      var rsg = RSG(INPUT_FILE, { config: undefined, title: 'foo' })
+    it('should be overwritten', () => {
+      const rsg = RSG(INPUT_FILE, {
+        config: undefined,
+        title: 'foo'
+      })
       assert.equal(rsg.opts.title, 'foo')
     })
 
-    it('should custom config file', function () {
-      var src = TMP_DIR + '/foo.json'
+    it('should custom config file', () => {
+      const src = TMP_DIR + '/foo.json'
       fs.outputFileSync(src, '{ "title": "foo" }')
 
-      var rsg = RSG(INPUT_FILE, { config: src })
+      const rsg = RSG(INPUT_FILE, {
+        config: src
+      })
       assert.equal(rsg.opts.title, 'foo')
       fs.removeSync(src)
     })
@@ -184,27 +202,27 @@ describe('RSG', function () {
     // this test is too heavy...
     this.timeout(60000)
 
-    var opts = {
+    const opts = {
       files: [
         '//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css',
         'example/example.css'
       ]
     }
 
-    var rsg = RSG(INPUT_FILE, opts)
-    var generated = rsg.generate()
+    const rsg = RSG(INPUT_FILE, opts)
+    const generated = rsg.generate()
 
-    it('files should exist', function (done) {
-      var files = [
+    it('files should exist', done => {
+      const files = [
         'index.html',
         'src/contents.js',
         'src/contents-inter.js',
         'src/react_' + rsg.reactVersion + '.js',
         'files/example.css'
-      ].map(function (file) { return getRealPath(TMP_DIR + '/' + file) })
+      ].map(file => getRealPath(TMP_DIR + '/' + file))
 
-      generated.then(function () {
-        assert(files.every(function (file) { return fs.existsSync(file) }))
+      generated.then(() => {
+        assert(files.every(file => fs.existsSync(file)))
         done()
       }).catch(done)
     })


### PR DESCRIPTION
- Classify `RSG` and export directly.
- Export `rsg()` to use without `new` syntax.